### PR TITLE
💄  update UI styles

### DIFF
--- a/Sputnik/ContentView.swift
+++ b/Sputnik/ContentView.swift
@@ -13,19 +13,28 @@ struct ContentView: View {
     
     var body: some View {
         VStack {
+            Spacer()
             HStack {
                 Button( action: {
                     self.document.back()
-                } ) {
-                    Text("←")
+                } )
+                {if #available(OSX 11.0, *) {
+                    Image(systemName: "arrow.left").imageScale(.small)
+                } else {
+                    Text("←")}
+                
                 }
                 .padding(.leading, 6)
+                
                 Button( action: {
                     self.document.forward()
-                } ) {
+                } ) {if #available(OSX 11.0, *) {
+                    Image(systemName: "arrow.right").imageScale(.small)
+                } else {
                     Text("→")
-                }
+                }}
                 TextField("Gemini Site", text: $document.navBarUrl, onCommit: browse)
+                Spacer()
             }
             
             GeminiDocumentView(document: document)


### PR DESCRIPTION
Use SF Symbols for the buttons on newer MacOS versions and add some spacing at toolbar.
Tested on MacOS `11.2.3` Big Sur

## preview
### before
![screenshot-before](https://user-images.githubusercontent.com/47633893/116364170-33f59480-a804-11eb-96aa-738aebdbf052.png)

### after
![screenshot-after](https://user-images.githubusercontent.com/47633893/116363845-d95c3880-a803-11eb-8ee2-5b74123ae9d0.png)
