### PR TITLE
✨  add theme switching and first custom theme

### DIFF
--- a/Sputnik.xcodeproj/project.pbxproj
+++ b/Sputnik.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		1AD2F57724FC43D700A7054D /* SubContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AD2F57624FC43D700A7054D /* SubContent.swift */; };
 		2292A4E8263B31E1008820A7 /* PreferencesTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2292A4E7263B31E1008820A7 /* PreferencesTab.swift */; };
 		22F08FBD263B11EB00CA0370 /* Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F08FBC263B11EB00CA0370 /* Preferences.swift */; };
+		22FA31A5263C904500C54EAC /* ThemeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FA31A4263C904500C54EAC /* ThemeData.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -37,6 +38,7 @@
 		2233E50F263BD10500F7AC0B /* Sputnik.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Sputnik.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2292A4E7263B31E1008820A7 /* PreferencesTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesTab.swift; sourceTree = "<group>"; };
 		22F08FBC263B11EB00CA0370 /* Preferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preferences.swift; sourceTree = "<group>"; };
+		22FA31A4263C904500C54EAC /* ThemeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeData.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -67,6 +69,7 @@
 				1AC8DD6124BA1B6C005F1206 /* GeminiDocument.swift */,
 				1AD2F57624FC43D700A7054D /* SubContent.swift */,
 				1A229B9324D63949003CAB7B /* Line.swift */,
+				22FA31A4263C904500C54EAC /* ThemeData.swift */,
 				1A37100C24B7D1D100E46EAF /* NetworkCall.swift */,
 				1A8F236324B68588001F4403 /* Assets.xcassets */,
 				1A8F236824B68588001F4403 /* Main.storyboard */,
@@ -163,6 +166,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1A8F236224B68586001F4403 /* ContentView.swift in Sources */,
+				22FA31A5263C904500C54EAC /* ThemeData.swift in Sources */,
 				1A8F236024B68586001F4403 /* AppDelegate.swift in Sources */,
 				1A37100D24B7D1D200E46EAF /* NetworkCall.swift in Sources */,
 				2292A4E8263B31E1008820A7 /* PreferencesTab.swift in Sources */,

--- a/Sputnik/Assets.xcassets/Colors/pref-colors/Contents.json
+++ b/Sputnik/Assets.xcassets/Colors/pref-colors/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sputnik/Assets.xcassets/Colors/pref-colors/coolGray.colorset/Contents.json
+++ b/Sputnik/Assets.xcassets/Colors/pref-colors/coolGray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.922",
+          "green" : "0.906",
+          "red" : "0.898"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.251",
+          "green" : "0.251",
+          "red" : "0.251"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sputnik/Assets.xcassets/Colors/pref-colors/white.colorset/Contents.json
+++ b/Sputnik/Assets.xcassets/Colors/pref-colors/white.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xEB",
-          "green" : "0xE7",
-          "red" : "0xE5"
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x40",
-          "green" : "0x40",
-          "red" : "0x40"
+          "blue" : "0.149",
+          "green" : "0.149",
+          "red" : "0.149"
         }
       },
       "idiom" : "universal"

--- a/Sputnik/Assets.xcassets/Colors/theme-colors/Contents.json
+++ b/Sputnik/Assets.xcassets/Colors/theme-colors/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sputnik/Assets.xcassets/Colors/theme-colors/satellite/Contents.json
+++ b/Sputnik/Assets.xcassets/Colors/theme-colors/satellite/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sputnik/Assets.xcassets/Colors/theme-colors/satellite/light-star-yellow.colorset/Contents.json
+++ b/Sputnik/Assets.xcassets/Colors/theme-colors/satellite/light-star-yellow.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x47",
+          "green" : "0xE0",
+          "red" : "0xFD"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x47",
+          "green" : "0xE0",
+          "red" : "0xFD"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sputnik/Assets.xcassets/Colors/theme-colors/satellite/spaceblue.colorset/Contents.json
+++ b/Sputnik/Assets.xcassets/Colors/theme-colors/satellite/spaceblue.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x3B",
+          "green" : "0x27",
+          "red" : "0x05"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x3B",
+          "green" : "0x27",
+          "red" : "0x05"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sputnik/Assets.xcassets/Colors/theme-colors/satellite/star-yellow.colorset/Contents.json
+++ b/Sputnik/Assets.xcassets/Colors/theme-colors/satellite/star-yellow.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xFF",
-          "green" : "0xFF",
-          "red" : "0xFF"
+          "blue" : "0x08",
+          "green" : "0xB3",
+          "red" : "0xEA"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x26",
-          "green" : "0x26",
-          "red" : "0x26"
+          "blue" : "0x08",
+          "green" : "0xB3",
+          "red" : "0xEA"
         }
       },
       "idiom" : "universal"

--- a/Sputnik/GeminiDocument.swift
+++ b/Sputnik/GeminiDocument.swift
@@ -27,7 +27,7 @@ struct GeminiDocumentView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(8)
-        .background(Color.black)
+        .background(ThemeData().backgroundColor)
     }
 }
 

--- a/Sputnik/Line.swift
+++ b/Sputnik/Line.swift
@@ -102,8 +102,8 @@ struct Line {
 
 struct LineView: View {
     var line: Line?
-    var background: Color = .black
-    let textColor = Color(red: 0.85, green: 0.85, blue: 0.85)
+    var background: Color = ThemeData().backgroundColor
+    let textColor: Color = ThemeData().textColor
     let textFont = "Palatino"
     let headingFont = "Luminari"
     let linkFont = "Helvetica Neue"
@@ -151,7 +151,7 @@ struct LineView: View {
             }) {
                 text.font(.custom(linkFont, size: 16))
                     .foregroundColor(target.scheme == "http" || target.scheme == "https" ?
-                        Color(red: 0, green: 0, blue: 1) : .blue)
+                                        ThemeData().httpLinkColor : ThemeData().linkColor)
             }.buttonStyle(PlainButtonStyle()))
             
         case .preformat:

--- a/Sputnik/Preferences.swift
+++ b/Sputnik/Preferences.swift
@@ -58,6 +58,8 @@ struct Preferences: View {
                         }){
                             Text("Save")
                         }
+                        
+                        Text("You may have to reopen the window that the changes take effect").font(.subheadline)
                     }
                     if page == "AboutView" {
                         Image("Icon-64")

--- a/Sputnik/ThemeData.swift
+++ b/Sputnik/ThemeData.swift
@@ -1,0 +1,64 @@
+//
+//  ThemeData.swift
+//  Sputnik
+//
+//  Created by Dietrich Poensgen on 30.04.21.
+//  Copyright © 2021 Peter Deal. All rights reserved.
+//
+
+import SwiftUI
+
+
+struct ThemeData {
+    var selectedThemeIndex = UserDefaults.standard.integer(forKey: "Theme")
+    
+    var textColor: Color
+    var linkColor: Color
+    var httpLinkColor: Color
+    
+    var backgroundColor: Color
+    
+    init() {
+       
+        // classic theme
+        if selectedThemeIndex == 0 {
+            textColor = Color(red: 0.85, green: 0.85, blue: 0.85)
+            linkColor = .blue
+            httpLinkColor = Color(red: 0, green: 0, blue: 1)
+            backgroundColor = .black
+        }
+        
+        // dark theme
+        if selectedThemeIndex == 1 {
+            textColor = .white
+            linkColor = .blue
+            httpLinkColor = Color(red: 0, green: 0, blue: 1)
+            backgroundColor = .black
+        }
+        
+        // light theme
+        if selectedThemeIndex == 2 {
+            textColor = .black
+            linkColor = .blue
+            httpLinkColor = Color(red: 0, green: 0, blue: 1)
+            backgroundColor = .white
+        }
+        
+        // satellite theme
+        if selectedThemeIndex == 3 {
+            textColor = .white
+            linkColor = Color("star-yellow")
+            httpLinkColor = Color("light-star-yellow")
+            backgroundColor = Color("spaceblue")
+        }
+        
+        // at fallback use classic theme
+        else {
+            textColor = .white
+            backgroundColor = .black
+            linkColor = .blue
+            httpLinkColor = Color(red: 0, green: 0, blue: 1)
+        }
+    }
+}
+


### PR DESCRIPTION
Now the app is switching between the different themes in ThemeData.swift, when the UserDefault Theme changes. Actually it needs to reopen the window that the changes take effect, but maybe there is a smarter way in the future. I already created a custom theme that should be similar to solarized. The ThemeData struct isn't completed yet, I plan to add other props, f.e. some for the fonts, in the future.